### PR TITLE
Fix variable name typo ('whitespace-cleanup-mode--initially-clean-p).

### DIFF
--- a/whitespace-cleanup-mode.el
+++ b/whitespace-cleanup-mode.el
@@ -56,7 +56,7 @@ enabled."
 
 (defvar whitespace-cleanup-mode-initially-clean nil
   "Records whether `whitespace-cleanup' was a no-op when the mode launched.")
-(make-variable-buffer-local 'whitespace-cleanup-mode--initially-clean-p)
+(make-variable-buffer-local 'whitespace-cleanup-mode-initially-clean)
 
 ;;;###autoload
 (define-minor-mode whitespace-cleanup-mode


### PR DESCRIPTION
Unless I'm mistaken, you missed a variable rename at some point.
