### PR TITLE
Fix the meaning of -only-if-initially-clean

### DIFF
--- a/whitespace-cleanup-mode.el
+++ b/whitespace-cleanup-mode.el
@@ -89,8 +89,8 @@ enabled."
 (defun whitespace-cleanup-mode-before-save ()
   "Function added to `before-save-hook'."
   (when (and whitespace-cleanup-mode
-             whitespace-cleanup-mode-only-if-initially-clean
-             whitespace-cleanup-mode-initially-clean)
+             (or (not whitespace-cleanup-mode-only-if-initially-clean)
+                 whitespace-cleanup-mode-initially-clean))
     (whitespace-cleanup)))
 
 


### PR DESCRIPTION
Currently the mode will _never_ cleanup whitespace if
`whitespace-cleanup-mode-only-if-initially-clean` is nil.  I don't think
that this is intended, so this PR changes the conditional to _always_
cleanup whitespace if the variable is nil.
