### PR TITLE
Autoload customize group

### DIFF
--- a/whitespace-cleanup-mode.el
+++ b/whitespace-cleanup-mode.el
@@ -50,7 +50,8 @@
 
 (require 'whitespace)
 
-(defgroup whitespace-cleanup-mode nil
+;;;###autoload
+(defgroup whitespace-cleanup nil
   "Automatically clean up whitespace on save."
   :group 'convenience)
 
@@ -62,13 +63,13 @@ to the end of the line's trimmed content.  When this variable is
 non-nil, then the trimmed space is re-added after save, but
 without marking the buffer as modified.  This allows
 uninterrupted editing with very short autosave intervals."
-  :group 'whitespace-cleanup-mode)
+  :group 'whitespace-cleanup)
 
 (defcustom whitespace-cleanup-mode-only-if-initially-clean t
   "When non-nil, only clean up whitespace at save if it was clean initially.
 The check for initial cleanliness is done when `whitespace-cleanup-mode' is
 enabled."
-  :group 'whitespace-cleanup-mode)
+  :group 'whitespace-cleanup)
 
 (defcustom whitespace-cleanup-mode-ignore-modes
   '(special-mode view-mode comint-mode cider-repl-mode haskell-interactive-mode)
@@ -77,7 +78,7 @@ If the major mode of a buffer is derived from one of these, then
  `global-whitespace-cleanup-mode' will not enable `whitespace-cleanup-mode'
  in that buffer."
   :type '(repeat symbol)
-  :group 'whitespace-cleanup-mode)
+  :group 'whitespace-cleanup)
 
 (defvar whitespace-cleanup-mode-initially-clean nil
   "Records whether `whitespace-cleanup' was a no-op when the mode launched.")


### PR DESCRIPTION
If you don't specify a group key in the globalized minor mode definition, the default group name is the name of the mode parameter minor the "-mode". Right now, this package actually created 2 customize groups: whitespace-cleanup and whitespace-cleanup-mode. This PR fixes that. This also follows the emacs convention. This PR also autoloads the customize group so the user can turn on global-whitespace-cleanup-mode entirely without having to fiddle with the init file.