### PR TITLE
Add support for enabling the mode locally

### DIFF
--- a/whitespace-cleanup-mode.el
+++ b/whitespace-cleanup-mode.el
@@ -80,9 +80,30 @@ If the major mode of a buffer is derived from one of these, then
   :type '(repeat symbol)
   :group 'whitespace-cleanup)
 
+(defcustom whitespace-cleanup-mode-enabled-globally t
+  "When non-nil, enable whitespace-cleanup-mode in all buffers.
+This is effective if `global-whitespace-cleanup-mode' is on.
+Otherwise, you have to set `whitespace-cleanup-mode-enabled-locally'
+in individual files/directories to turn on `whitespace-cleanup-mode'
+automatically."
+  :type 'boolean
+  :group 'whitespace-cleanup)
+
 (defvar whitespace-cleanup-mode-initially-clean nil
   "Records whether `whitespace-cleanup' was a no-op when the mode launched.")
 (make-variable-buffer-local 'whitespace-cleanup-mode-initially-clean)
+
+(defvar whitespace-cleanup-mode-enabled-locally nil
+  "Automatically turn on `whitespace-cleanup-mode' in this buffer.
+
+If the value is t, `global-whitespace-cleanup-mode' turns
+on `whitespace-cleanup-mode', even when
+`whitespace-cleanup-mode-enabled-globally' is off.
+
+This variable is intended to be set locally either as a
+file-local variable or directory-local variable.")
+(make-variable-buffer-local 'whitespace-cleanup-mode-enabled-locally)
+(put 'whitespace-cleanup-mode-enabled-locally 'safe-local-variable 'booleanp)
 
 (defun whitespace-cleanup-mode-buffer-is-clean-p ()
   "Return t iff the whitespace in the current buffer is clean."
@@ -127,8 +148,10 @@ Use '!' to signify that the buffer was not initially clean."
 
 (defun turn-on-whitespace-cleanup-mode ()
   "Enable `whitespace-cleanup-mode' if appropriate in this buffer."
-  (unless (or (minibufferp)
-              (apply 'derived-mode-p whitespace-cleanup-mode-ignore-modes))
+  (when (and (or whitespace-cleanup-mode-enabled-globally
+                 whitespace-cleanup-mode-enabled-locally)
+             (not (or (minibufferp)
+                      (apply 'derived-mode-p whitespace-cleanup-mode-ignore-modes))))
     (whitespace-cleanup-mode 1)))
 
 (defun whitespace-cleanup-mode-write-file ()

--- a/whitespace-cleanup-mode.el
+++ b/whitespace-cleanup-mode.el
@@ -80,30 +80,24 @@ If the major mode of a buffer is derived from one of these, then
   :type '(repeat symbol)
   :group 'whitespace-cleanup)
 
-(defcustom whitespace-cleanup-mode-enabled-globally t
-  "When non-nil, enable whitespace-cleanup-mode in all buffers.
-This is effective if `global-whitespace-cleanup-mode' is on.
-Otherwise, you have to set `whitespace-cleanup-mode-enabled-locally'
-in individual files/directories to turn on `whitespace-cleanup-mode'
-automatically."
+(defcustom whitespace-cleanup-mode-enabled t
+  "When non-nil, `global-whitespace-cleanup-mode' enables `whitespace-cleanup-mode'.
+
+If you set the default value of this variable to non-nil,
+`global-whitespace-cleanup-mode' turns on `whitespace-cleanup-mode'
+in all buffers.
+
+Alternatively, you can set the default value to nil but set it to
+t as a local variable in individual files and directories to turn
+on `whitespace-cleanup-mode' only in specific projects."
   :type 'boolean
-  :group 'whitespace-cleanup)
+  :group 'whitespace-cleanup
+  :safe t)
+(make-variable-buffer-local 'whitespace-cleanup-mode-enabled)
 
 (defvar whitespace-cleanup-mode-initially-clean nil
   "Records whether `whitespace-cleanup' was a no-op when the mode launched.")
 (make-variable-buffer-local 'whitespace-cleanup-mode-initially-clean)
-
-(defvar whitespace-cleanup-mode-enabled-locally nil
-  "Automatically turn on `whitespace-cleanup-mode' in this buffer.
-
-If the value is t, `global-whitespace-cleanup-mode' turns
-on `whitespace-cleanup-mode', even when
-`whitespace-cleanup-mode-enabled-globally' is off.
-
-This variable is intended to be set locally either as a
-file-local variable or directory-local variable.")
-(make-variable-buffer-local 'whitespace-cleanup-mode-enabled-locally)
-(put 'whitespace-cleanup-mode-enabled-locally 'safe-local-variable 'booleanp)
 
 (defun whitespace-cleanup-mode-buffer-is-clean-p ()
   "Return t iff the whitespace in the current buffer is clean."
@@ -148,10 +142,9 @@ Use '!' to signify that the buffer was not initially clean."
 
 (defun turn-on-whitespace-cleanup-mode ()
   "Enable `whitespace-cleanup-mode' if appropriate in this buffer."
-  (when (and (or whitespace-cleanup-mode-enabled-globally
-                 whitespace-cleanup-mode-enabled-locally)
-             (not (or (minibufferp)
-                      (apply 'derived-mode-p whitespace-cleanup-mode-ignore-modes))))
+  (unless (or (minibufferp)
+              (not whitespace-cleanup-mode-enabled)
+              (apply 'derived-mode-p whitespace-cleanup-mode-ignore-modes))
     (whitespace-cleanup-mode 1)))
 
 (defun whitespace-cleanup-mode-write-file ()


### PR DESCRIPTION
This patch solves #9. That is, it allows the user to turn on `whitespace-cleanup-mode` only in specific files and/or directories via local variables.

## Usage

To turn on `whitespace-cleanup-mode` only in specific files and directories, follow this instruction:

1. Set `whitespace-cleanup-mode-enabled`, which is non-nil by default, to nil. 
2. Turn on `global-whitespace-mode`.

An example configuration with `use-package`:

```emacs-lisp
(use-package whitespace-cleanup-mode
  :custom
  (whitespace-cleanup-mode-enabled nil)
  :config
  (global-whitespace-cleanup-mode t))
```

Then you can set `whitespace-cleanup-mode-enabled` to non-nil in specific files/projects where you want to turn on `whitespace-cleanup-mode` automatically. The following is an example of `.dir-locals.el` which enables the mode in emacs-lisp-mode:

```emacs-lisp
((emacs-lisp-mode
  (whitespace-cleanup-mode-enabled . t)))
```